### PR TITLE
Custom ip arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Although UDPComms isn't ideal for commands that need to be processed in order (a
 ### Publisher Arguments 
 - `port`
 The port the messages will be sent on. If you are part of Stanford Student Robotics make sure there isn't any port conflicts by checking the `UDP Ports` sheet of the [CS Comms System](https://docs.google.com/spreadsheets/d/1pqduUwYa1_sWiObJDrvCCz4Al3pl588ytE4u-Dwa6Pw/edit?usp=sharing) document. If you are not I recommend keep track of your port numbers somewhere. It's possible that in the future UDPComms will have a system of naming (with a string) as opposed to numbering publishers. 
+- `ip` By default UDPComms sends to the `10.0.0.X` subnet, but can be changed to a different ip using this argument. Set to localhost (`127.0.0.1`) for development on the same computer. 
 
 ### Subscriber Arguments 
 

--- a/UDPComms.py
+++ b/UDPComms.py
@@ -26,8 +26,10 @@ timeout = socket.timeout
 
 MAX_SIZE = 65507
 
+DEFAULT_IP = "10.0.0.255"
+
 class Publisher:
-    def __init__(self, port):
+    def __init__(self, port, ip = DEFAULT_IP):
         """ Create a Publisher Object
 
         Arguments:
@@ -35,9 +37,8 @@ class Publisher:
         """
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-        self.broadcast_ip = "127.0.0.1"
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        self.broadcast_ip = "10.0.0.255"
+        self.broadcast_ip = ip
 
         self.sock.settimeout(0.2)
         self.sock.connect((self.broadcast_ip, port))

--- a/UDPComms.py
+++ b/UDPComms.py
@@ -34,6 +34,7 @@ class Publisher:
 
         Arguments:
             port         -- the port to publish the messages on
+            ip           -- the ip to send the messages to
         """
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 


### PR DESCRIPTION
Allows you to set a custom ip for UDPComms Publisher. I found that merely setting ip to 127.0.0.1 allowed me to easily to local development, although that was just with some simple scripts I made. By default ip is set to its original at 10.0.0.255. 